### PR TITLE
remove potentially controversial *cock*

### DIFF
--- a/usr/share/petname/medium/names.txt
+++ b/usr/share/petname/medium/names.txt
@@ -178,8 +178,6 @@ coati
 coatimundi
 cobia
 cobra
-cockatoo
-cockroach
 cod
 codling
 coelacanth
@@ -663,7 +661,6 @@ parrot
 parrotfish
 partridge
 passerine
-peacock
 peafowl
 peccary
 pegasus
@@ -1036,7 +1033,6 @@ wolfhound
 wolverine
 wombat
 woodchuck
-woodcock
 woodcreeper
 woodlouse
 woodpecker

--- a/usr/share/petname/small/names.txt
+++ b/usr/share/petname/small/names.txt
@@ -339,7 +339,6 @@ octopus
 opossum
 ostrich
 panther
-peacock
 pegasus
 pelican
 penguin
@@ -388,7 +387,6 @@ bonefish
 bullfrog
 cardinal
 chipmunk
-cockatoo
 crayfish
 dinosaur
 doberman
@@ -449,4 +447,3 @@ titmouse
 tortoise
 treefrog
 werewolf
-woodcock


### PR DESCRIPTION
We got `postgres-classic-woodcock` today and while we got a good chuckle out of it, it feels like something we'd regret down the line. So here goes :)