### PR TITLE
Add recently removed animal names to blacklist

### DIFF
--- a/debian/blacklist.txt
+++ b/debian/blacklist.txt
@@ -75,6 +75,8 @@ cloverclamps
 clusterfuck
 cock
 cocks
+cockatoo
+cockroach
 coprolagnia
 coprophilia
 cornhole
@@ -240,6 +242,7 @@ paedophile
 paki
 panties
 panty
+peacock
 pedobear
 pedophile
 pegging
@@ -369,6 +372,7 @@ wetback
 wetdream
 whitepower
 wrappingmen
+woodcock
 wrinkledstarfish
 xx
 xxx


### PR DESCRIPTION
## Summary
Adds `cockatoo`, `cockroach`, `peacock`, and `woodcock` to `debian/blacklist.txt`.

These animal names were removed from the wordlists in PR #6 to avoid potentially awkward professional combinations. Adding them to the blacklist ensures they stay filtered out and maintains consistency with other previously removed words like `jackass`, `donkey`, `swine`, and `termite`.

## Related
- PR #6: Remove potentially controversial animal names from wordlists

🤖 Generated with [Claude Code](https://claude.com/claude-code)